### PR TITLE
Set met and metplus environmental variables in run_vx.local.lua modulefiles

### DIFF
--- a/modulefiles/tasks/cheyenne/run_vx.local.lua
+++ b/modulefiles/tasks/cheyenne/run_vx.local.lua
@@ -1,6 +1,25 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
-load(pathJoin("met", os.getenv("met_ver") or "10.1.2"))
-load(pathJoin("metplus", os.getenv("metplus_ver") or "4.1.3"))
+local met_ver = (os.getenv("met_ver") or "10.1.2")
+local metplus_ver = (os.getenv("metplus_ver") or "4.1.3")
+if (mode() == "load") then
+  load(pathJoin("met", met_ver))
+  load(pathJoin("metplus",metplus_ver))
+end
+local base_met = os.getenv("met_ROOT") or os.getenv("MET_ROOT")
+local base_metplus = os.getenv("metplus_ROOT") or os.getenv("METPLUS_ROOT")
+
+setenv("MET_INSTALL_DIR", base_met)
+setenv("MET_BIN_EXEC",    pathJoin(base_met,"bin"))
+setenv("MET_BASE",        pathJoin(base_met,"share/met"))
+setenv("MET_VERSION",     met_ver)
+setenv("MET_VERSION",     metplus_ver)
+setenv("METPLUS_ROOT",    base_metplus)
+setenv("METPLUS_PATH",    base_metplus)
+
+if (mode() == "unload") then
+  unload(pathJoin("met", met_ver))
+  unload(pathJoin("metplus",metplus_ver))
+end
 load("python_srw")

--- a/modulefiles/tasks/derecho/run_vx.local.lua
+++ b/modulefiles/tasks/derecho/run_vx.local.lua
@@ -1,6 +1,25 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
-load(pathJoin("met", os.getenv("met_ver") or "10.1.2"))
-load(pathJoin("metplus", os.getenv("metplus_ver") or "4.1.3"))
+local met_ver = (os.getenv("met_ver") or "10.1.2")
+local metplus_ver = (os.getenv("metplus_ver") or "4.1.3")
+if (mode() == "load") then
+  load(pathJoin("met", met_ver))
+  load(pathJoin("metplus",metplus_ver))
+end
+local base_met = os.getenv("met_ROOT") or os.getenv("MET_ROOT")
+local base_metplus = os.getenv("metplus_ROOT") or os.getenv("METPLUS_ROOT")
+
+setenv("MET_INSTALL_DIR", base_met)
+setenv("MET_BIN_EXEC",    pathJoin(base_met,"bin"))
+setenv("MET_BASE",        pathJoin(base_met,"share/met"))
+setenv("MET_VERSION",     met_ver)
+setenv("MET_VERSION",     metplus_ver)
+setenv("METPLUS_ROOT",    base_metplus)
+setenv("METPLUS_PATH",    base_metplus)
+
+if (mode() == "unload") then
+  unload(pathJoin("met", met_ver))
+  unload(pathJoin("metplus",metplus_ver))
+end
 load("python_srw")

--- a/modulefiles/tasks/gaea/run_vx.local.lua
+++ b/modulefiles/tasks/gaea/run_vx.local.lua
@@ -1,6 +1,25 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
-load(pathJoin("met", os.getenv("met_ver") or "10.1.2"))
-load(pathJoin("metplus", os.getenv("metplus_ver") or "4.1.3"))
+local met_ver = (os.getenv("met_ver") or "10.1.1")
+local metplus_ver = (os.getenv("metplus_ver") or "4.1.1")
+if (mode() == "load") then
+  load(pathJoin("met", met_ver))
+  load(pathJoin("metplus",metplus_ver))
+end
+local base_met = os.getenv("met_ROOT") or os.getenv("MET_ROOT")
+local base_metplus = os.getenv("metplus_ROOT") or os.getenv("METPLUS_ROOT")
+
+setenv("MET_INSTALL_DIR", base_met)
+setenv("MET_BIN_EXEC",    pathJoin(base_met,"bin"))
+setenv("MET_BASE",        pathJoin(base_met,"share/met"))
+setenv("MET_VERSION",     met_ver)
+setenv("MET_VERSION",     metplus_ver)
+setenv("METPLUS_ROOT",    base_metplus)
+setenv("METPLUS_PATH",    base_metplus)
+
+if (mode() == "unload") then
+  unload(pathJoin("met", met_ver))
+  unload(pathJoin("metplus",metplus_ver))
+end
 load("python_srw")

--- a/modulefiles/tasks/hera/run_vx.local.lua
+++ b/modulefiles/tasks/hera/run_vx.local.lua
@@ -1,6 +1,25 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
-load(pathJoin("met", os.getenv("met_ver") or "10.1.1"))
-load(pathJoin("metplus", os.getenv("metplus_ver") or "4.1.1"))
+local met_ver = (os.getenv("met_ver") or "10.1.1")
+local metplus_ver = (os.getenv("metplus_ver") or "4.1.1")
+if (mode() == "load") then
+  load(pathJoin("met", met_ver))
+  load(pathJoin("metplus",metplus_ver))
+end
+local base_met = os.getenv("met_ROOT") or os.getenv("MET_ROOT")
+local base_metplus = os.getenv("metplus_ROOT") or os.getenv("METPLUS_ROOT")
+
+setenv("MET_INSTALL_DIR", base_met)
+setenv("MET_BIN_EXEC",    pathJoin(base_met,"bin"))
+setenv("MET_BASE",        pathJoin(base_met,"share/met"))
+setenv("MET_VERSION",     met_ver)
+setenv("MET_VERSION",     metplus_ver)
+setenv("METPLUS_ROOT",    base_metplus)
+setenv("METPLUS_PATH",    base_metplus)
+
+if (mode() == "unload") then
+  unload(pathJoin("met", met_ver))
+  unload(pathJoin("metplus",metplus_ver))
+end
 load("python_srw")

--- a/modulefiles/tasks/jet/run_vx.local.lua
+++ b/modulefiles/tasks/jet/run_vx.local.lua
@@ -1,6 +1,25 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
-load(pathJoin("met", os.getenv("met_ver") or "10.1.2"))
-load(pathJoin("metplus", os.getenv("metplus_ver") or "4.1.3"))
+local met_ver = (os.getenv("met_ver") or "10.1.1")
+local metplus_ver = (os.getenv("metplus_ver") or "4.1.1")
+if (mode() == "load") then
+  load(pathJoin("met", met_ver))
+  load(pathJoin("metplus",metplus_ver))
+end
+local base_met = os.getenv("met_ROOT") or os.getenv("MET_ROOT")
+local base_metplus = os.getenv("metplus_ROOT") or os.getenv("METPLUS_ROOT")
+
+setenv("MET_INSTALL_DIR", base_met)
+setenv("MET_BIN_EXEC",    pathJoin(base_met,"bin"))
+setenv("MET_BASE",        pathJoin(base_met,"share/met"))
+setenv("MET_VERSION",     met_ver)
+setenv("MET_VERSION",     metplus_ver)
+setenv("METPLUS_ROOT",    base_metplus)
+setenv("METPLUS_PATH",    base_metplus)
+
+if (mode() == "unload") then
+  unload(pathJoin("met", met_ver))
+  unload(pathJoin("metplus",metplus_ver))
+end
 load("python_srw")

--- a/modulefiles/tasks/noaacloud/run_vx.local.lua
+++ b/modulefiles/tasks/noaacloud/run_vx.local.lua
@@ -1,6 +1,25 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
-load(pathJoin("met", os.getenv("met_ver") or "10.1.2"))
-load(pathJoin("metplus", os.getenv("metplus_ver") or "4.1.3"))
+local met_ver = (os.getenv("met_ver") or "10.1.1")
+local metplus_ver = (os.getenv("metplus_ver") or "4.1.1")
+if (mode() == "load") then
+  load(pathJoin("met", met_ver))
+  load(pathJoin("metplus",metplus_ver))
+end
+local base_met = os.getenv("met_ROOT") or os.getenv("MET_ROOT")
+local base_metplus = os.getenv("metplus_ROOT") or os.getenv("METPLUS_ROOT")
+
+setenv("MET_INSTALL_DIR", base_met)
+setenv("MET_BIN_EXEC",    pathJoin(base_met,"bin"))
+setenv("MET_BASE",        pathJoin(base_met,"share/met"))
+setenv("MET_VERSION",     met_ver)
+setenv("MET_VERSION",     metplus_ver)
+setenv("METPLUS_ROOT",    base_metplus)
+setenv("METPLUS_PATH",    base_metplus)
+
+if (mode() == "unload") then
+  unload(pathJoin("met", met_ver))
+  unload(pathJoin("metplus",metplus_ver))
+end
 load("python_srw")

--- a/modulefiles/tasks/orion/run_vx.local.lua
+++ b/modulefiles/tasks/orion/run_vx.local.lua
@@ -1,6 +1,26 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
-load(pathJoin("met", os.getenv("met_ver") or "10.1.2"))
-load(pathJoin("metplus", os.getenv("metplus_ver") or "4.1.3"))
+local met_ver = (os.getenv("met_ver") or "10.1.1")
+local metplus_ver = (os.getenv("metplus_ver") or "4.1.1")
+if (mode() == "load") then 
+  load(pathJoin("met", met_ver))
+  load(pathJoin("metplus",metplus_ver))
+end
+local base_met = os.getenv("met_ROOT") or os.getenv("MET_ROOT")
+local base_metplus = os.getenv("metplus_ROOT") or os.getenv("METPLUS_ROOT")
+
+setenv("MET_INSTALL_DIR", base_met)
+setenv("MET_BIN_EXEC",    pathJoin(base_met,"bin"))
+setenv("MET_BASE",        pathJoin(base_met,"share/met"))
+setenv("MET_VERSION",     met_ver)
+setenv("MET_VERSION",     metplus_ver)
+setenv("METPLUS_ROOT",    base_metplus)
+setenv("METPLUS_PATH",    base_metplus)
+
+if (mode() == "unload") then 
+  unload(pathJoin("met", met_ver))
+  unload(pathJoin("metplus",metplus_ver))
+end
 load("python_srw")
+

--- a/ush/machine/orion.yaml
+++ b/ush/machine/orion.yaml
@@ -32,3 +32,13 @@ platform:
   FIXsfc: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/fix/fix_sfc_climo
   FIXshp: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/NaturalEarth
   EXTRN_MDL_DATA_STORES: aws nomads
+data:
+  ics_lbcs:
+    FV3GFS:
+      nemsio: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/input_model_data/FV3GFS/nemsio/${yyyymmdd}${hh}
+      grib2: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/input_model_data/FV3GFS/grib2/${yyyymmdd}${hh}
+      netcdf: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/input_model_data/FV3GFS/netcdf/${yyyymmdd}${hh}
+    NAM: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/input_model_data/NAM/${yyyymmdd}${hh}
+    HRRR: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/input_model_data/HRRR/${yyyymmdd}${hh}
+    RAP: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/input_model_data/RAP/${yyyymmdd}${hh}
+    GSMGFS: /work/noaa/epic/role-epic/contrib/UFS_SRW_data/develop/input_model_data/GSMGFS/${yyyymmdd}${hh}


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

Set environmental variables for met and metplus modules in ./modulefiles/tasks/<machine>/run_vx.local.lua . These variables are present in hpc-stack modulefiles and are not defined in spack-stack modulefiles. 
<machine> is a specific platform, i.e., hera, gaea, orion, jet, noaacloud, cheyenne/derecho.  

Files changed:
./modulefiles/tasks/orion/run_vx.local.lua
./modulefiles/tasks/hera/run_vx.local.lua
./modulefiles/tasks/gaea/run_vx.local.lua
./modulefiles/tasks/cheyenne/run_vx.local.lua
./modulefiles/tasks/jet/run_vx.local.lua
./modulefiles/tasks/derecho/run_vx.local.lua
./ush/machine/orion.yaml

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
Four met verifications tests were run on Orion with hpc-stack and spack-stack, with similar run_vx.local.lua (all similar except for the module versions).

Spack-stack:

```
All 4 experiments finished
Calculating core-hour usage and printing final summary
----------------------------------------------------------------------------------------------------
Experiment name                                                  | Status    | Core hours used 
----------------------------------------------------------------------------------------------------
MET_verification                                                   COMPLETE              11.86
MET_verification_only_vx                                           COMPLETE               0.25
MET_ensemble_verification                                          COMPLETE              21.91
MET_ensemble_verification_only_vx                                  COMPLETE               1.05
----------------------------------------------------------------------------------------------------
Total                                                              COMPLETE              35.07

Detailed summary written to /work/noaa/epic/nperlin/SRW/expt_dirs/spack/WE2E_summary_20230924073715.txt
```

With hpc-stack:

```
All 4 experiments finished
Calculating core-hour usage and printing final summary
----------------------------------------------------------------------------------------------------
Experiment name                                                  | Status    | Core hours used 
----------------------------------------------------------------------------------------------------
MET_verification                                                   COMPLETE              10.12
MET_verification_only_vx                                           COMPLETE               0.15
MET_ensemble_verification                                          COMPLETE              19.17
MET_ensemble_verification_only_vx                                  COMPLETE               0.89
----------------------------------------------------------------------------------------------------
Total                                                              COMPLETE              30.33
Detailed summary written to /work/noaa/epic/nperlin/SRW/expt_dirs/hpc/WE2E_summary_20230924073905.txt
```

<!-- Add an X to check off a box. -->

- [ ] hera.intel
- [x] orion.intel (with spack-stack)
- [x] orion.intel (with hpc-stack)
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)

## DEPENDENCIES:
https://github.com/ufs-community/ufs-srweather-app/issues/905
https://github.com/ufs-community/ufs-srweather-app/pull/901 (merged)
https://github.com/ufs-community/ufs-srweather-app/pull/913

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->

## ISSUE: 
Use of Met and Metplus modules built with spack-stack/1.4.1 need additional environmental variables to be used by the SRW. These additional variables were present in met and metplus modules built with hpc-stack.

## CHECKLIST
<!-- Add an X to check off a box. -->
- [x] My code follows the style guidelines in the Contributor's Guide
- [x] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes do not require updates to the documentation (explain).
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [x] Work In Progress
- [x] bug (currently for noaacloud)
- [x] enhancement
- [ ] documentation
- [x] release
- [x] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->

