### PR TITLE
Update run_vx.local.lua to allow verification tests to run on Orion.

### DIFF
--- a/modulefiles/tasks/orion/run_vx.local.lua
+++ b/modulefiles/tasks/orion/run_vx.local.lua
@@ -1,6 +1,8 @@
 --[[
 Compiler-specific modules are used for met and metplus libraries
 --]]
+load("build_orion_intel")
+
 local met_ver = (os.getenv("met_ver") or "11.1.0")
 local metplus_ver = (os.getenv("metplus_ver") or "5.1.0")
 if (mode() == "load") then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add `load("build_orion_intel")` to `modulefiles/tasks/orion/run_vx.local.lua` in order to allow the verification tests to run on Orion.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## TESTS CONDUCTED: 
- [X] orion.intel - Successfully ran verification tests on Orion.

## CHECKLIST
- [X] My code follows the style guidelines in the Contributor's Guide
- [X] I have performed a self-review of my own code using the Code Reviewer's Guide
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes