### PR TITLE
Update documentation

### DIFF
--- a/doc/UsersGuide/BuildingRunningTesting/RunSRW.rst
+++ b/doc/UsersGuide/BuildingRunningTesting/RunSRW.rst
@@ -58,13 +58,15 @@ The SRW App requires input files to run. These include static datasets, initial 
    * - Gaea-C6
      - /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/|data|/input_model_data/
    * - Hera
-     - /scratch1/NCEPDEV/nems/role.epic/UFS_SRW_data/|data|/input_model_data/
+     - /scratch3/NCEPDEV/nems/role.epic/hera/UFS_SRW_data/|data|/input_model_data
    * - Hercules
      - /work/noaa/epic/role-epic/contrib/UFS_SRW_data/|data|/input_model_data//
    * - NOAA Cloud
      - /contrib/EPIC/UFS_SRW_data/|data|/input_model_data/
    * - Orion
      - /work/noaa/epic/role-epic/contrib/UFS_SRW_data/|data|/input_model_data/
+   * - Ursa
+     - /scratch3/NCEPDEV/nems/role.epic/ursa/UFS_SRW_data/|data|/input_model_data
 
 For Level 2-4 systems, the data must be added to the user's system. Detailed instructions on how to add the data can be found in :numref:`Section %s: Downloading and Staging Input Data <DownloadingStagingInput>`. Sections :numref:`%s: Input Files <Input>` and :numref:`%s: Output Files <OutputFiles>` contain useful background information on the input and output files used in the SRW App.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,9 +15,9 @@ for the current code in the users ufs-srweather-app directory.  It consists of t
 
 Currently, the following configurations are supported:
 
-Machine     | Derecho | Ursa   | Hera   | Jet    | Orion  | wcoss2  |
-------------|---------|--------|--------|--------|--------|---------|
-Compiler(s) | Intel   | Intel  | Intel  | Intel  | Intel  | Intel   |
+Machine     | Derecho | Gaea C6 | Hera        | Hercules | Orion   | Ursa        |
+------------|---------|---------|-------------|----------|---------|-------------|
+Compiler(s) | Intel   | Intel   | Intel, GNU  | Intel    | Intel   | Intel, GNU  |
 
 The CMake build is done in the ``build_${compiler}`` directory.
 The executables for each build are installed under the ``bin_${compiler}`` directory.


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* Updated documentation in `tests/README.md` to note that Hera and Ursa tests both Intel and GNU
* Updated documentation in `doc/UsersGuide/BuildingRunningTesting/RunSRW.rst` to note updated locations for external model data on Hera and Ursa

### Type of change
- [x] Documention update

## TESTS CONDUCTED: 
The GitHub Action, `Doc Tests`, successfully [passed](https://github.com/MichaelLueken/ufs-srweather-app/actions/runs/18130751091/job/51596599596)